### PR TITLE
Fix typo SSL config

### DIFF
--- a/docs/thehive/installation-and-configuration/configuration/database.md
+++ b/docs/thehive/installation-and-configuration/configuration/database.md
@@ -205,7 +205,7 @@ Database and index engine can be different, depending on the use case and target
                         }
                       }
                       ssl {
-                        enable: true
+                        enabled: true
                         truststore {
                           location: /path/to/your/truststore.jks
                           password: truststorepwd


### PR DESCRIPTION
Fixes **IllegalArgumentException** when using `ssl.enable` instead of `ssl.enabled`.

`
An error occurs (java.lang.IllegalArgumentException: Could not instantiate implementation: org.janusgraph.diskstorage.es.ElasticSearchIndex)
`