### PR TITLE
Add information about default user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.9
+
+VOLUME [ "/docs" ]
+WORKDIR /docs
+CMD [ "mkdocs", "serve", "-a", "0.0.0.0:8000" ]
+
+ADD requirements.txt /tmp
+RUN pip install -r /tmp/requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # docs
+
+The documentation uses mkdocs to render the content.
+
+```
+# Install the requirements first
+pip install -r requirements.txt
+
+# Start the mkdocs server in development mode
+mkdocs serve
+```
+
+Alternatively you can use a docker container:
+
+```
+docker build . -t thehive-docs
+docker run -it --rm -p 8000:8000 -v $PWD:/docs thehive-docs
+```

--- a/docs/thehive/installation-and-configuration/installation/step-by-step-guide.md
+++ b/docs/thehive/installation-and-configuration/installation/step-by-step-guide.md
@@ -583,6 +583,8 @@ service thehive start
 
 Please note that the service may take some time to start. Once it is started, you may launch your browser and connect to `http://YOUR_SERVER_ADDRESS:9000/`.
 
+The default admin user is `admin@thehive.local` with password `secret`. It is recommended to change the default password.
+
 
 ## Advanced configuration
 For additional configuration options, please refer to the [Configuration Guides](../index.md#configuration-guides).


### PR DESCRIPTION
This PR adds information about the init user available in The Hive.
This also adds instruction about how to build the documentation locally